### PR TITLE
Remove the ability to change the name of phase

### DIFF
--- a/src/main/java/net/theevilreaper/xerus/api/phase/Phase.java
+++ b/src/main/java/net/theevilreaper/xerus/api/phase/Phase.java
@@ -1,34 +1,36 @@
 package net.theevilreaper.xerus.api.phase;
 
-import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Patrick Zdarsky / Rxcki
  * @version 1.0
  * @since 03/01/2020 21:00
- *
+ * <br>
  * Describes any Phase which will be externally started and which can finish at some point,
  * when the phase finishes it can notify a listener using the {@code finishedCallback}
  */
 public abstract class Phase {
 
-    private String name = "Unnamed phase";
+    private final String name;
     private boolean running;
     private boolean finished;
     private boolean skipping;
 
     private Runnable finishedCallback;
 
-    protected Phase() { }
-
+    /**
+     * Creates a new reference of the {@link Phase} with the given parameters.
+     *
+     * @param name the name of the phase, used to identify it
+     */
     protected Phase(@NotNull String name) {
         this.name = name;
     }
 
     /**
      * Used to start the phase.
-     *
+     * <p>
      * A phase can only be started once, so when running is true the phase won't be started
      */
     public void start() {
@@ -41,11 +43,12 @@ public abstract class Phase {
 
     protected abstract void onStart();
 
-    public void onSkip() {}
+    public void onSkip() {
+    }
 
     /**
      * Used to finish the phase.
-     *
+     * <p>
      * A phase can only be finished once, so when finished is true the phase won't be stated as finished again
      */
     public void finish() {
@@ -63,16 +66,12 @@ public abstract class Phase {
         return this;
     }
 
-    public void setName(@NotNull String name) {
-        Check.argCondition(name.trim().isEmpty(), "The name can't be empty");
-        this.name = name;
-    }
-
     /**
-     * @return The name of this phase
+     * Returns the name representing this phase.
+     *
+     * @return the given name
      */
-    @NotNull
-    public String getName() {
+    public @NotNull String getName() {
         return name;
     }
 
@@ -104,6 +103,7 @@ public abstract class Phase {
 
     /**
      * Sets the callback which will be called when the phase is finished
+     *
      * @param finishedCallback The callback to be called when the phase finished
      */
     public void setFinishedCallback(Runnable finishedCallback) {

--- a/src/test/java/net/theevilreaper/xerus/api/phase/PhaseStructureTest.java
+++ b/src/test/java/net/theevilreaper/xerus/api/phase/PhaseStructureTest.java
@@ -17,7 +17,7 @@ class PhaseStructureTest {
 
     @BeforeAll
     void init() {
-        this.phase = new Phase() {
+        this.phase = new Phase("Test") {
             @Override
             protected void onStart() {
                 throw new RuntimeException("Start called");
@@ -60,51 +60,37 @@ class PhaseStructureTest {
 
     @Order(5)
     @Test
-    void testSetName() {
-        this.phase.setName("New name");
-        assertSame("New name", this.phase.getName());
-    }
-
-    @Order(6)
-    @Test
-    void testSetNameWithException() {
-        assertThrowsExactly(IllegalArgumentException.class,
-                () -> this.phase.setName(" "), "The name can't be empty");
-    }
-
-    @Order(7)
-    @Test
     void testIsRunning() {
         assertFalse(this.phase.isRunning());
     }
 
-    @Order(8)
+    @Order(6)
     @Test
     void testIsFinished() {
         assertTrue(this.phase.isFinished());
     }
 
-    @Order(9)
+    @Order(7)
     @Test
     void testSetFinish() {
         this.phase.setFinished(false);
         assertFalse(this.phase.isFinished());
     }
 
-    @Order(10)
+    @Order(8)
     @Test
     void testIsSkipping() {
         assertFalse(this.phase.isSkipping());
     }
 
-    @Order(11)
+    @Order(9)
     @Test
     void testSetSkipping() {
         this.phase.setSkipping(true);
         assertTrue(this.phase.isSkipping());
     }
 
-    @Order(12)
+    @Order(10)
     @Test
     void testSetFinishCallback() {
         this.phase.setFinishedCallback(null);


### PR DESCRIPTION
## Proposed changes

There is no valid reason for a Phase to have a method that allows changing its internal name after creation. Doing so would break several context-based checks. This `PR` removes that method.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...