### PR TITLE
refactor: player collection usage

### DIFF
--- a/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
+++ b/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
@@ -3,14 +3,14 @@ package net.theevilreaper.xerus.api;
 import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Locale;
 
 /**
  * Contains some methods that help to set the player items.
  *
  * @author theEvilReaper
- * @version 1.1.0
+ * @version 1.2.0
  * @since 1.2.0
  **/
 @FunctionalInterface
@@ -42,11 +42,11 @@ public interface ItemShiftOption {
      * @param players      the players who receive the equipment
      * @param shiftedSlots array containing shifted slots for the items
      */
-    default void setEquipment(List<Player> players, int... shiftedSlots) {
+    default void setEquipment(Collection<Player> players, int... shiftedSlots) {
         if (players.isEmpty()) return;
 
-        for (int i = 0; i < players.size(); i++) {
-            this.setEquipment(players.get(i), shiftedSlots);
+        for (Player player : players) {
+            this.setEquipment(player, shiftedSlots);
         }
     }
 }

--- a/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
+++ b/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
@@ -10,7 +10,7 @@ import java.util.Locale;
  * Contains some methods that help to set the player items.
  *
  * @author theEvilReaper
- * @version 1.2.0
+ * @version 1.3.0
  * @since 1.2.0
  **/
 @FunctionalInterface
@@ -26,7 +26,7 @@ public interface ItemShiftOption {
     void setEquipment(Player player, Locale locale, int... shiftedSlots);
 
     /**
-     * Sets an equipment to an specific player.
+     * Sets equipment to a specific player.
      *
      * @param player       the player who receives the equipment
      * @param shiftedSlots array containing shifted slots for the items
@@ -45,8 +45,6 @@ public interface ItemShiftOption {
     default void setEquipment(Collection<Player> players, int... shiftedSlots) {
         if (players.isEmpty()) return;
 
-        for (Player player : players) {
-            this.setEquipment(player, shiftedSlots);
-        }
+        players.forEach(player -> setEquipment(player, shiftedSlots));
     }
 }

--- a/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
+++ b/src/main/java/net/theevilreaper/xerus/api/ItemShiftOption.java
@@ -2,6 +2,7 @@ package net.theevilreaper.xerus.api;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -23,7 +24,7 @@ public interface ItemShiftOption {
      * @param locale       the locale to determine the right items
      * @param shiftedSlots specifies whether the items should be added in a different order
      */
-    void setEquipment(Player player, Locale locale, int... shiftedSlots);
+    void setEquipment(Player player, @Nullable Locale locale, int @Nullable ... shiftedSlots);
 
     /**
      * Sets equipment to a specific player.

--- a/src/main/java/net/theevilreaper/xerus/api/Joinable.java
+++ b/src/main/java/net/theevilreaper/xerus/api/Joinable.java
@@ -3,76 +3,76 @@ package net.theevilreaper.xerus.api;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.Consumer;
 
 /**
- * The interface provides some method to add a single player object or a set off players.
+ * The interface provides some method to add a single player object or a collection of players.
  * Each developer can implement the interface into his class but must write his own logic for the methods.
  *
  * @author theEvilReaper
- * @version 1.1.0
+ * @version 1.2.0
  * @since 1.0.0
  */
 public interface Joinable {
 
     /**
      * Add a single player
-     * @param paramPlayer The player to add
+     * @param player The player to add
      */
-    default void addPlayer(Player paramPlayer) {
-        this.addPlayer(paramPlayer, null);
+    default void addPlayer(Player player) {
+        this.addPlayer(player, null);
     }
 
     /**
      * Add a single {@link Player} entry to a structure.
-     * @param paramPlayer the player to add
+     * @param player the player to add
      * @param consumer a consumer which is called to execute some logic
      */
-    void addPlayer(Player paramPlayer, @Nullable Consumer<Player> consumer);
+    void addPlayer(Player player, @Nullable Consumer<Player> consumer);
 
     /**
-     * Add a set off players
-     * @param players The set which contains the players to add
+     * Add a collection of players
+     * @param players The collection which contains the players to add
      */
-    default void addPlayers(Set<Player> players) {
+    default void addPlayers(Collection<Player> players) {
         this.addPlayers(players, null);
     }
 
     /**
-     * Add a set off players
-     * @param players The set which contains the players to add
+     * Add a collection of players
+     * @param players The collection which contains the players to add
      * @param consumer a consumer which is called to execute some logic
      */
-    void addPlayers(Set<Player> players, @Nullable Consumer<Player> consumer);
+    void addPlayers(Collection<Player> players, @Nullable Consumer<Player> consumer);
 
     /**
      * Remove a single player
-     * @param paramPlayer The player to remove
+     * @param player The player to remove
      */
-    default void removePlayer(Player paramPlayer) {
-        this.removePlayer(paramPlayer, null);
+    default void removePlayer(Player player) {
+        this.removePlayer(player, null);
     }
 
     /**
      * Remove a single {@link Player} entry from a structure.
-     * @param paramPlayer the player to remove
+     * @param player the player to remove
      * @param consumer a consumer which is called to execute some logic
      */
-    void removePlayer(Player paramPlayer, @Nullable Consumer<Player> consumer);
+    void removePlayer(Player player, @Nullable Consumer<Player> consumer);
 
     /**
-     * Remove a set off players
-     * @param players The set which contains the players to remove
+     * Remove a collection of players
+     * @param players The collection which contains the players to remove
      */
-    default void removePlayers(Set<Player> players) {
+    default void removePlayers(Collection<Player> players) {
         this.removePlayers(players, null);
     }
 
     /**
-     * Remove a set off players
-     * @param players The set which contains the players to remove
+     * Remove a collection of players
+     * @param players The collection which contains the players to remove
      * @param consumer a consumer which is called to execute some logic
      */
-    void removePlayers(Set<Player> players, @Nullable Consumer<Player> consumer);
+    void removePlayers(Collection<Player> players, @Nullable Consumer<Player> consumer);
 }

--- a/src/main/java/net/theevilreaper/xerus/api/team/Team.java
+++ b/src/main/java/net/theevilreaper/xerus/api/team/Team.java
@@ -11,6 +11,7 @@ import net.minestom.server.event.EventDispatcher;
 import net.theevilreaper.xerus.api.team.event.TeamAction;
 import org.jetbrains.annotations.*;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -75,7 +76,7 @@ public interface Team extends Joinable, Componentable, Comparator<Team> {
      * @param consumer a consumer which is called to execute some logic
      */
     @Override
-    default void addPlayers(@NotNull Set<Player> players, @Nullable Consumer<Player> consumer) {
+    default void addPlayers(@NotNull Collection<Player> players, @Nullable Consumer<Player> consumer) {
         if (players.isEmpty()) return;
         players.removeIf(player -> !getPlayers().add(player));
         Runnable successCallback = consumer == null ? EMPTY : () -> getPlayers().forEach(consumer);
@@ -103,7 +104,7 @@ public interface Team extends Joinable, Componentable, Comparator<Team> {
      * @param consumer a consumer which is called to execute some logic
      */
     @Override
-    default void removePlayers(@NotNull Set<Player> players, @Nullable Consumer<Player> consumer) {
+    default void removePlayers(@NotNull Collection<Player> players, @Nullable Consumer<Player> consumer) {
         if (players.isEmpty()) return;
         players.removeIf(player -> getPlayers().contains(player));
         Runnable successCallback = consumer == null ? EMPTY : () -> getPlayers().forEach(consumer);

--- a/src/main/java/net/theevilreaper/xerus/api/team/event/MultiPlayerTeamEvent.java
+++ b/src/main/java/net/theevilreaper/xerus/api/team/event/MultiPlayerTeamEvent.java
@@ -6,20 +6,20 @@ import net.minestom.server.event.Event;
 import net.minestom.server.event.trait.CancellableEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * The event will be fired if an action is applied to a team where more than one player is involved.
  * There is a separate event for it, so that the event is called with only one player less
  *
  * @author theEvilReaper
- * @version 1.1.0
+ * @version 1.2.0
  * @since 1.0.11
  **/
 public class MultiPlayerTeamEvent implements Event, CancellableEvent {
 
     private final Team team;
-    private final Set<Player> players;
+    private final Collection<Player> players;
     private final TeamAction action;
     private boolean cancelled;
 
@@ -27,10 +27,10 @@ public class MultiPlayerTeamEvent implements Event, CancellableEvent {
      * Event is called when multiple players interact with a team.
      *
      * @param team       the team which is involved in the event
-     * @param players    the set with the players who are involved in the event
+     * @param players    the collection with the players who are involved in the event
      * @param teamAction the action for the event
      */
-    public MultiPlayerTeamEvent(@NotNull Team team, @NotNull Set<Player> players, @NotNull TeamAction teamAction) {
+    public MultiPlayerTeamEvent(@NotNull Team team, @NotNull Collection<Player> players, @NotNull TeamAction teamAction) {
         this.team = team;
         this.players = players;
         this.action = teamAction;
@@ -59,10 +59,10 @@ public class MultiPlayerTeamEvent implements Event, CancellableEvent {
     /**
      * Returns the players who are involved in this event.
      *
-     * @return the set with the involved players
+     * @return the collection with the involved players
      */
     @NotNull
-    public Set<Player> getPlayers() {
+    public Collection<Player> getPlayers() {
         return players;
     }
 

--- a/src/test/java/net/theevilreaper/xerus/api/JoinableTest.java
+++ b/src/test/java/net/theevilreaper/xerus/api/JoinableTest.java
@@ -50,4 +50,20 @@ class JoinableTest {
         this.joinable.removePlayers(players);
         assertTrue(this.joinable.getPlayers().isEmpty());
     }
+
+    @Test
+    void testMultipleOperationWithList(Env env) {
+        final Instance instance = env.createFlatInstance();
+        final var playersList = java.util.List.of(
+                env.createPlayer(instance, Pos.ZERO),
+                env.createPlayer(instance, Pos.ZERO)
+        );
+
+        assertTrue(this.joinable.getPlayers().isEmpty());
+        this.joinable.addPlayers(playersList);
+        assertEquals(2, this.joinable.getPlayers().size());
+
+        this.joinable.removePlayers(playersList);
+        assertTrue(this.joinable.getPlayers().isEmpty());
+    }
 }

--- a/src/test/java/net/theevilreaper/xerus/api/mocks/TestJoinableImpl.java
+++ b/src/test/java/net/theevilreaper/xerus/api/mocks/TestJoinableImpl.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -18,47 +19,55 @@ public class TestJoinableImpl implements Joinable {
     }
 
     @Override
-    public void addPlayer(@NotNull Player paramPlayer) {
-        this.players.add(paramPlayer);
+    public void addPlayer(@NotNull Player player) {
+        this.players.add(player);
     }
 
     @Override
-    public void addPlayer(@NotNull Player paramPlayer, @Nullable Consumer<Player> consumer) {
-        this.players.add(paramPlayer);
+    public void addPlayer(@NotNull Player player, @Nullable Consumer<Player> consumer) {
+        this.players.add(player);
 
         if (consumer != null) {
-            consumer.accept(paramPlayer);
+            consumer.accept(player);
         }
     }
 
     @Override
-    public void addPlayers(@NotNull Set<Player> players) {
+    public void addPlayers(@NotNull Collection<Player> players) {
         this.players.addAll(players);
     }
 
     @Override
-    public void addPlayers(@NotNull Set<Player> players, @Nullable Consumer<Player> consumer) {
-
+    public void addPlayers(@NotNull Collection<Player> players, @Nullable Consumer<Player> consumer) {
+        this.players.addAll(players);
+        if (consumer != null) {
+            players.forEach(consumer);
+        }
     }
 
     @Override
-    public void removePlayer(@NotNull Player paramPlayer) {
-        this.players.remove(paramPlayer);
+    public void removePlayer(@NotNull Player player) {
+        this.players.remove(player);
     }
 
     @Override
-    public void removePlayer(@NotNull Player paramPlayer, @Nullable Consumer<Player> consumer) {
-
+    public void removePlayer(@NotNull Player player, @Nullable Consumer<Player> consumer) {
+        if (this.players.remove(player) && consumer != null) {
+            consumer.accept(player);
+        }
     }
 
     @Override
-    public void removePlayers(@NotNull Set<Player> players) {
+    public void removePlayers(@NotNull Collection<Player> players) {
         this.players.removeAll(players);
     }
 
     @Override
-    public void removePlayers(@NotNull Set<Player> players, @Nullable Consumer<Player> consumer) {
-
+    public void removePlayers(@NotNull Collection<Player> players, @Nullable Consumer<Player> consumer) {
+        this.players.removeAll(players);
+        if (consumer != null) {
+            players.forEach(consumer);
+        }
     }
 
     public Set<Player> getPlayers() {


### PR DESCRIPTION
## Proposed changes

Currently, `ItemShiftOption` and `Joinables` require a `List` of players for certain methods. This unnecessarily restricts the API, as other collection types cannot be used. This pull request changes the affected methods to accept a `Collection` instead, making the API more flexible

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)