### PR TITLE
feat(color)!: add TeamColor mapping and rename ambiguous constants

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(libs.cyano)
     testImplementation(libs.adventure)
     testImplementation(libs.junit.api)
+    testImplementation(libs.junit.params)
     testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.junit)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ dependencyResolutionManagement {
             library("mockito.core", "org.mockito", "mockito-core").withoutVersion()
             library("mockito.junit", "org.mockito", "mockito-junit-jupiter").withoutVersion()
             library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").withoutVersion()
+            library("junit.params", "org.junit.jupiter", "junit-jupiter-params").withoutVersion()
         }
     }
 }

--- a/src/main/java/net/theevilreaper/xerus/api/ColorData.java
+++ b/src/main/java/net/theevilreaper/xerus/api/ColorData.java
@@ -3,14 +3,18 @@ package net.theevilreaper.xerus.api;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.color.Color;
 import net.minestom.server.color.DyeColor;
+import net.minestom.server.color.TeamColor;
 import net.minestom.server.item.Material;
+
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Represents a mapping of visual color variants using text color, dye color, block material, and a string identifier.
  * Each constant aligns with a specific base color and can be used to harmonize visual elements across different systems.
  *
  * @author theEvilReaper
- * @version 1.6.0
+ * @version 1.7.0
  * @since 1.0.0
  */
 @SuppressWarnings("java:S3252")
@@ -40,14 +44,14 @@ public enum ColorData {
     /** Aligns with the dark gray color. */
     DARK_GRAY(NamedTextColor.DARK_GRAY, DyeColor.GRAY, Material.GRAY_WOOL, "colorDarkGray"),
 
+    /** Aligns with the dark green color. */
+    DARK_GREEN(NamedTextColor.DARK_GREEN, DyeColor.GREEN, Material.GREEN_WOOL, "colorGreen"),
+
     /** Aligns with the green color. */
-    GREEN(NamedTextColor.DARK_GREEN, DyeColor.GREEN, Material.GREEN_WOOL, "colorGreen"),
+    GREEN(NamedTextColor.GREEN, DyeColor.LIME, Material.LIME_WOOL, "colorLime"),
 
-    /** Aligns with the light green color. */
-    LIGHT_GREEN(NamedTextColor.GREEN, DyeColor.LIME, Material.LIME_WOOL, "colorLime"),
-
-    /** Aligns with the purple color. */
-    PURPLE(NamedTextColor.DARK_PURPLE, DyeColor.PURPLE, Material.PURPLE_WOOL, "colorPurple"),
+    /** Aligns with the dark purple color. */
+    DARK_PURPLE(NamedTextColor.DARK_PURPLE, DyeColor.PURPLE, Material.PURPLE_WOOL, "colorPurple"),
 
     /** Aligns with the light purple color. */
     LIGHT_PURPLE(NamedTextColor.LIGHT_PURPLE, DyeColor.MAGENTA, Material.MAGENTA_WOOL, "colorMagenta"),
@@ -66,6 +70,20 @@ public enum ColorData {
 
     //Reduce defensive copies from the array, because values() returns each call a new array!
     private static final ColorData[] VALUES = values();
+
+    private static final Map<ColorData, TeamColor> TEAM_COLOR_CACHE = new EnumMap<>(ColorData.class);
+
+    static {
+        for (ColorData colorData : VALUES) {
+            TeamColor mapped = TeamColor.fromName(colorData.chatColor.toString());
+            if (mapped == null) {
+                throw new ExceptionInInitializerError(
+                        "No TeamColor mapping found for ColorData " + colorData.name()
+                );
+            }
+            TEAM_COLOR_CACHE.put(colorData, mapped);
+        }
+    }
 
     private final NamedTextColor chatColor;
     private final DyeColor dyeColor;
@@ -130,6 +148,17 @@ public enum ColorData {
      */
     public Color getColor() {
         return this.dyeColor.color();
+    }
+
+    /**
+     * Returns the matching {@link TeamColor} for this entry, resolved via the underlying
+     * {@link NamedTextColor} rather than the enum name to avoid mismatches
+     * (e.g. this enum's {@code DARK_GREEN} maps to {@link NamedTextColor#DARK_GREEN}).
+     *
+     * @return the underlying teamColor
+     */
+    public TeamColor toTeamColor() {
+        return TEAM_COLOR_CACHE.get(this);
     }
 
     /**

--- a/src/test/java/net/theevilreaper/xerus/api/ColorDataTest.java
+++ b/src/test/java/net/theevilreaper/xerus/api/ColorDataTest.java
@@ -3,8 +3,11 @@ package net.theevilreaper.xerus.api;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.color.Color;
 import net.minestom.server.color.DyeColor;
+import net.minestom.server.color.TeamColor;
 import net.minestom.server.item.Material;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,5 +28,17 @@ class ColorDataTest {
     @Test
     void testLength() {
         assertSame(16, ColorData.getValues().length);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ColorData.class)
+    void testToTeamColorMatchesChatColor(ColorData colorData) {
+        TeamColor teamColor = colorData.toTeamColor();
+        NamedTextColor chatColor = colorData.getChatColor();
+
+        assertNotNull(teamColor);
+        assertEquals(chatColor.red(), teamColor.red());
+        assertEquals(chatColor.green(), teamColor.green());
+        assertEquals(chatColor.blue(), teamColor.blue());
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds ColorData#toTeamColor() to map colors onto Minestom's new TeamColor enum, resolved via NamedTextColor rather than enum name to avoid mismatches. Renames three ambiguous constants (GREEN→DARK_GREEN, LIGHT_GREEN→GREEN, PURPLE→DARK_PURPLE) so enum names match their actual NamedTextColor, which is a breaking change for any consumer referencing the old names.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)